### PR TITLE
fix(configuration): setDeprecated method requires arguments

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ final class Configuration implements ConfigurationInterface
         $rootNode
             ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->setDeprecated()->end()
+                ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->setDeprecated('loevgaard/sylius-brand-plugin', '2.0')->end()
         ;
 
         $this->addResourcesSection($rootNode);


### PR DESCRIPTION
Running this plugin with Sylius 1.13 and Symfony 6.

This was deprecated from Symfony 5.X

https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php#L171

From Symfony 6, arguments are required:

```
Too few arguments to function Symfony\Component\Config\Definition\Builder\NodeDefinition::setDeprecated(), 0 passed in /vendor/subitolabs/sylius-plugin-brand/src/DependencyInjection/Configuration.php on line 32 and at least 2 expected
```